### PR TITLE
Use the class as identifier for the logger

### DIFF
--- a/src/es/icarto/gvsig/navtableforms/AbstractForm.java
+++ b/src/es/icarto/gvsig/navtableforms/AbstractForm.java
@@ -78,12 +78,12 @@ PositionListener {
     private ValidationHandlerForCheckBoxes validationHandlerForCheckBoxes;
     private ValidationHandlerForTextAreas validationHandlerForTextAreas;
 
-    private static Logger logger = null;
+    protected static Logger logger = null;
     private ORMLite ormlite;
 
     public AbstractForm(FLyrVect layer) {
 	super(layer);
-	logger = getLoggerName();
+	logger = Logger.getLogger(getClass());
 	formBody = getFormBody();
 	initValidation();
     }
@@ -107,7 +107,10 @@ PositionListener {
 
     public abstract String getXMLPath();
 
-    public abstract Logger getLoggerName();
+    @Deprecated
+    public Logger getLoggerName() {
+	return Logger.getLogger(getClass());
+    }
 
     @Override
     public JPanel getCenterPanel() {


### PR DESCRIPTION
Use the name of the class as identifier for the logger is a good programming practice. With this change the use of the child class as identifier is forced, and less configuration on the child is need. 

The logger field is defined as protected to allow be used by childs

With this change:
- There is no need to override getLoggerForm to get an instance of the Logger.
- The logger field can be used anywhere on the form. 
  logger.debug("Hi world!") in ExampleForm will produce as output 
  DEBUG [AWT-EventQueue-1](ExampleForm.java.java:13) - Hi world!
